### PR TITLE
Linux port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE OpenCL::OpenCL)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 11
                                                  C_STANDARD_REQUIRED ON
-                                                 C_EXTENSIONS OFF)
+                                                 C_EXTENSIONS ON)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE CL_TARGET_OPENCL_VERSION=100)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ Build:
 Run:
 `.\build\Release\Immolate.exe`
 
+### Linux (Debian)
+Install dependencies:
+
+```
+sudo apt-get install cmake ocl-icd-opencl-dev build-essentials
+```
+
+_NOTE: Remember to install the OpenCL driver depending on your hardware._
+
+Build:
+```
+cmake -B build
+cmake --build build --config Release
+```
+
+Run:
+```
+./build/Immolate
+```
+
+
 ## Future Plans
 - Full support with all features in Balatro 1.0.
 - Support for AMD GPUs.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Run:
 Install dependencies:
 
 ```
-sudo apt-get install cmake ocl-icd-opencl-dev build-essentials
+sudo apt-get install cmake ocl-icd-opencl-dev build-essential
 ```
 
 _NOTE: Remember to install the OpenCL driver depending on your hardware._

--- a/lib/immolate.h
+++ b/lib/immolate.h
@@ -1,13 +1,67 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <windows.h>
+#ifdef _WIN32
+    #include <windows.h>
+    #define PATH_SEPARATOR "\\"
+#else
+    // Define undefined MAX_PATH in Linux
+    #define MAX_PATH (1024)
+    #define PATH_SEPARATOR "/"
+
+    #include <unistd.h>
+    #include <libgen.h>
+
+    /* Use unsafe not _s functions
+     * An alternative is using safeclib implementation with the following:
+     *
+     * #define __STDC_WANT_LIB_EXT1__ 1
+     * #include <safeclib/safe_str_lib.h>
+     * 
+     * Unfortunately, the strcat_s and strcpy_s do not work for malloced strings
+     */
+    #define strcat_s(a,b,c) strcat(a,c)
+    #define strcpy_s(a,b,c) strcpy(a,c)
+    #define printf_s(...) printf(__VA_ARGS__)
+    #define fprintf_s(...) fprintf(__VA_ARGS__)
+#endif
 #include <limits.h>
 #include <string.h>
 #include <CL/cl.h>
+#define MAX_CODE_SIZE (1000000)
+
 void clErrCheck(cl_int err, char* msg) {
     if (err != CL_SUCCESS) {
-        printf_s("Fatal CL Error %d when trying to execute %s", err, msg);
-        exit(1);
+        printf_s("Fatal CL Error %d when trying to execute %s\n", err, msg);
+        exit(EXIT_FAILURE);
     }
+}
+
+void getExecutableDir(char *dir) {
+    #ifdef _WIN32
+        // Windows specific code
+         if (GetModuleFileName(NULL, dir, MAX_PATH) != 0) {
+            char* last_slash = strrchr(dir, '\\');
+            if (last_slash != NULL) {
+                *last_slash = '\0';
+            }
+        } else {
+            fprintf(stderr, "Error: Unable to get the current working directory\n");
+        }
+    #elif __linux__
+        // Linux specific code
+        ssize_t len = readlink("/proc/self/exe", dir, (size_t)(MAX_PATH - 1));
+        if (len != -1) {
+            dir[len] = '\0';
+            char* last_slash = strrchr(dir, '/');
+            if (last_slash != NULL) {
+                *last_slash = '\0';
+            }
+        } else {
+            fprintf(stderr, "Error: Unable to get the current working directory\n");
+            // exit(EXIT_FAILURE);
+        }
+    #else
+        #error Platform not supported
+    #endif
 }


### PR DESCRIPTION
This PR introduces very basic Linux support. Fixes #26.

These changes have been made to the source code to make this happen:
* Conditionally including header files based on the platform 
* Move the logic to locate `Immolate` executable path in its own function, which is platform dependent
* Define the `MAX_PATH` constant which is not defined in a Linux environment
* Define the `_s` variants of functions to non `_s` variants ones since GCC / Clang do not ship those by default
* Added support to extensions to the C compiler, which would otherwise complain about the `readlink` function

Additionally, some minor bugs have been fixed:
* Added formats to some `printf_s` which would use string buffers as formats instead of using `"%s`
* Made the `main` function always return an integer
* Added some `\n` here and there
* Using `EXIT_SUCCESS` and `EXIT_FAILURE` instead of 0 and 1

Finally, some bare-bone documentation has been added for the Debian distribution, which should be similar to other distributions too.

It would be cool to include CI/CD building and/or Docker, but unfortunately I do not have time for that.

Thanks for the great project! I see that you are porting it to C++, I do understand if this MR does not get merged in!