### PR TITLE
Add 0 to valid seed characters

### DIFF
--- a/lib/seed.cl
+++ b/lib/seed.cl
@@ -1,6 +1,6 @@
 // Some important definitions
-__constant char SEEDCHARS[] = "123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-__constant int NUM_CHARS = 35;
+__constant char SEEDCHARS[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+__constant int NUM_CHARS = 36;
 
 int s_char_num(char c){
     return c - (49 + (c>57)*7);

--- a/lib/seed.cl
+++ b/lib/seed.cl
@@ -3,7 +3,7 @@ __constant char SEEDCHARS[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 __constant int NUM_CHARS = 36;
 
 int s_char_num(char c){
-    return c - (49 + (c>57)*7);
+    return c - (48 + (c>57)*7);
 }
 
 typedef struct Seed {


### PR DESCRIPTION
Super small change, but was going through the source and noticed that `0` wasn't included in the seed characters, so this PR adds 0 to the list of valid seed characters.